### PR TITLE
3-to-be-able-to-throw-an-exception-when-a-session-key-is-not-found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New exception `SessionKeyNotFoundException` to throw when a key is not found a the session array.
+
 ## [0.2.0] 2020-09-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Using the methods you will discover below has the advantage to be able to give m
 - [4. UrlNotFoundException](#4-urlnotfoundexception)
 - [5. HistoryNotFoundException](#5-historynotfoundexception)
 - [6. RouteNotFoundException](#6-routenotfoundexception)
+- [7. SessionKeyNotFoundException](7-sessionkeynotfoundexception)
 
 ### 1. FolderNotFoundException
 
@@ -174,6 +175,23 @@ try {
   throw $exception;
 } catch (RouteNotFoundException $exception) {
   echo "route {$exception->getRoute()} not found";
+}
+```
+
+### 7. SessionKeyNotFoundException
+
+In this example, we will throw an exception if a key is not found in a session array.
+
+```php
+use Folded\Exceptions\SessionKeyNotFoundException;
+
+try {
+  $exception = new SessionKeyNotFoundException("key foo not found");
+  $exception->setKey("foo");
+
+  throw $exception;
+} catch (SessionKeyNotFoundException $exception) {
+  echo "key {$exception->getKey()} not found";
 }
 ```
 

--- a/src/Exceptions/SessionKeyNotFoundException.php
+++ b/src/Exceptions/SessionKeyNotFoundException.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Folded\Exceptions;
+
+use Throwable;
+use OutOfRangeException;
+
+/**
+ * Represents an error when a key is not found in a session array.
+ *
+ * @since 0.3.0
+ */
+class SessionKeyNotFoundException extends OutOfRangeException
+{
+    /**
+     * The key name that is not found in the session.
+     *
+     * @since 0.3.0
+     */
+    private string $key;
+
+    /**
+     * Constructor.
+     *
+     * @param null|mixed $message  The error message.
+     * @param int        $code     The error code.
+     * @param Exception  $previous The exception that have produced this exception.
+     *
+     * @since 0.3.0
+     *
+     * @example
+     * $exception = new FolderNotFoundException("folder foo not found");
+     */
+    public function __construct($message = null, $code = 0, ?Throwable $previous = null)
+    {
+        $this->key = "";
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * Get the key name that is not found in the session.
+     *
+     * @since 0.3.0
+     *
+     * @example
+     * $exception = new SessionKeyNotFoundException("key foo not found");
+     *
+     * $exception->setKey("foo");
+     *
+     * echo $exception->getKey();
+     */
+    public function getKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * Set the key that is not found in the session.
+     *
+     * @param string $name The name of the key that is not found.
+     *
+     * @since 0.3.0
+     *
+     * @example
+     * $exception = new SessionKeyNotFoundException("key foo not found");
+     *
+     * $exception->setKey("foo");
+     */
+    public function setKey(string $name): self
+    {
+        $this->key = $name;
+
+        return $this;
+    }
+}

--- a/tests/Exceptions/SessionKeyNotFoundExceptionTest.php
+++ b/tests/Exceptions/SessionKeyNotFoundExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types = 1);
+
+use Folded\Exceptions\SessionKeyNotFoundException;
+
+it("should set the key when throwing a SessionKeyNotFoundException", function (): void {
+    $key = "foo";
+
+    try {
+        throw (new SessionKeyNotFoundException("key $key not found"))->setKey($key);
+    } catch (SessionKeyNotFoundException $exception) {
+        expect($exception->getKey())->tobe($key);
+    }
+});


### PR DESCRIPTION
## Added 

- New exception `SessionKeyNotFoundException` to throw when a key is not found in a session array.

## Fixed

None.

## Breaking

None.